### PR TITLE
Fix catkin build --this in nested workspaces

### DIFF
--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -150,15 +150,7 @@ def find_enclosing_workspace(search_start_path):
     workspaces = find_enclosing_workspaces(search_start_path)
     if not workspaces:
         return None
-    if len(workspaces) == 1:
-        return workspaces[0]
-
-    print('Multiple nested workspaces have been found for search path `{}`:\n'.format(search_start_path),
-          file=sys.stderr)
-    for workspace in workspaces:
-        print(' - {}'.format(workspace), file=sys.stderr)
-    print('\nPlease select one of them explicitly by adding the --workspace (-w) argument.', file=sys.stderr)
-    sys.exit(1)
+    return workspaces[0]
 
 def migrate_metadata(workspace_path):
     """Migrate metadata if it's out of date."""


### PR DESCRIPTION
The patch in https://github.com/Intermodalics/catkin_tools/pull/1 broke `catkin build --this` if the package is located in a nested workspace because cli.py also calls `find_enclosing_workspace()` in this case.

The implementation of `find_enclosing_workspace()` has therefore been reverted to only return the innermost workspace path. The check for multiple nested workspaces has been moved to method Context.load(), such that it only applies for finding the catkin_tools context.