### PR TITLE
Detect nested workspaces and use the outermost workspace by default

### DIFF
--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -48,7 +48,7 @@ def add_workspace_arg(parser):
 
     add = parser.add_argument
     add('--workspace', '-w', default=None,
-        help='The path to the catkin_tools workspace or a directory contained within it (default: ".")')
+        help='The path to the catkin_tools workspace (default: autodetect)')
 
 
 def add_cmake_and_make_and_catkin_make_args(parser):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -27,7 +27,7 @@ from .common import printed_fill
 from .common import remove_ansi_escape
 from .common import terminal_width
 
-from .metadata import find_enclosing_workspaces
+from .metadata import find_enclosing_workspace
 
 from .resultspace import get_resultspace_environment
 
@@ -176,19 +176,7 @@ class Context(object):
 
         # Get the workspace (either the given directory or the enclosing ws)
         workspace_hint = workspace_hint or opts_vars.get('workspace', None) or getcwd()
-        workspaces = find_enclosing_workspaces(workspace_hint)
-        if not workspaces:
-            workspace = None
-        elif len(workspaces) == 1:
-            workspace = workspaces[0]
-        else:
-            print('Multiple nested workspaces have been found for search path `{}`:\n'.format(workspace_hint),
-                file=sys.stderr)
-            for workspace in workspaces:
-                print(' - {}'.format(workspace), file=sys.stderr)
-            print('\nPlease select one of them explicitly by adding the --workspace (-w) argument.', file=sys.stderr)
-            sys.exit(1)
-
+        workspace = find_enclosing_workspace(workspace_hint)
         if not workspace:
             if strict or not workspace_hint:
                 return None
@@ -668,7 +656,7 @@ class Context(object):
 
     def initialized(self):
         """Check if this context is initialized."""
-        return self.workspace in (find_enclosing_workspaces(self.workspace) or [])
+        return self.workspace == find_enclosing_workspace(self.workspace)
 
     @property
     def destdir(self):

--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -27,7 +27,7 @@ from .common import printed_fill
 from .common import remove_ansi_escape
 from .common import terminal_width
 
-from .metadata import find_enclosing_workspace
+from .metadata import find_enclosing_workspaces
 
 from .resultspace import get_resultspace_environment
 
@@ -174,9 +174,15 @@ class Context(object):
         # Initialize dictionary version of opts namespace
         opts_vars = vars(opts) if opts else {}
 
-        # Get the workspace (either the given directory or the enclosing ws)
-        workspace_hint = workspace_hint or opts_vars.get('workspace', None) or getcwd()
-        workspace = find_enclosing_workspace(workspace_hint)
+        # Get the workspace (either the given directory or the ws enclosing cwd)
+        workspace_hint = workspace_hint or opts_vars.get('workspace', None)
+        if workspace_hint:
+            workspace = workspace_hint
+        else:
+            workspaces = find_enclosing_workspaces(getcwd())
+            if workspaces:
+                workspace = workspaces[-1]
+
         if not workspace:
             if strict or not workspace_hint:
                 return None
@@ -656,7 +662,7 @@ class Context(object):
 
     def initialized(self):
         """Check if this context is initialized."""
-        return self.workspace == find_enclosing_workspace(self.workspace)
+        return self.workspace in (find_enclosing_workspaces(self.workspace) or [])
 
     @property
     def destdir(self):

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 import pkg_resources
 import shutil
+import sys
 import yaml
 
 from .common import mkdir_p
@@ -103,6 +104,29 @@ def get_paths(workspace_path, profile_name, verb=None):
 
     return (metadata_path, metadata_file_path)
 
+def find_enclosing_workspaces(search_start_path):
+    """Find a catkin workspaces based on the existence of a catkin_tools
+    metadata directory starting in the path given by search_path and traversing
+    each parent directory and returns a list of workspaces.
+
+    :search_start_path: Directory which either is a catkin workspace or is
+    contained in a catkin workspace
+
+    :returns: List of path to the workspaces if found, an empty list otherwise.
+    """
+    workspaces = []
+    while search_start_path:
+        # Check if marker file exists
+        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
+        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
+            workspaces.append(search_start_path)
+
+        # Update search path or end
+        (search_start_path, child_path) = os.path.split(search_start_path)
+        if len(child_path) == 0:
+            break
+
+    return workspaces
 
 def find_enclosing_workspace(search_start_path):
     """Find a catkin workspace based on the existence of a catkin_tools
@@ -110,24 +134,18 @@ def find_enclosing_workspace(search_start_path):
     each parent directory until either finding such a directory or getting to
     the root of the filesystem.
 
+    If more than one candidate exists, returns the topmost workspace (closest
+    to the root of the filesystem.
+
     :search_start_path: Directory which either is a catkin workspace or is
     contained in a catkin workspace
 
     :returns: Path to the workspace if found, `None` if not found.
     """
-    while search_start_path:
-        # Check if marker file exists
-        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
-        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
-            return search_start_path
-
-        # Update search path or end
-        (search_start_path, child_path) = os.path.split(search_start_path)
-        if len(child_path) == 0:
-            break
-
-    return None
-
+    workspaces = find_enclosing_workspaces(search_start_path)
+    if not workspaces:
+        return None
+    return workspaces[-1]
 
 def migrate_metadata(workspace_path):
     """Migrate metadata if it's out of date."""
@@ -215,7 +233,8 @@ def init_metadata_root(workspace_path, reset=False):
             "not exist." % (workspace_path))
 
     # Check if the desired workspace is enclosed in another workspace
-    marked_workspace = find_enclosing_workspace(workspace_path)
+    marked_workspace = find_enclosing_workspaces(workspace_path)
+    if marked_workspace: marked_workspace = marked_workspace[0]
 
     if marked_workspace and marked_workspace != workspace_path:
         raise IOError(

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -150,7 +150,15 @@ def find_enclosing_workspace(search_start_path):
     workspaces = find_enclosing_workspaces(search_start_path)
     if not workspaces:
         return None
-    return workspaces[0]
+    if len(workspaces) == 1:
+        return workspaces[0]
+
+    print('Multiple nested workspaces have been found for search path `{}`:\n'.format(search_start_path),
+          file=sys.stderr)
+    for workspace in workspaces:
+        print(' - {}'.format(workspace), file=sys.stderr)
+    print('\nPlease select one of them explicitly by adding the --workspace (-w) argument.', file=sys.stderr)
+    sys.exit(1)
 
 def migrate_metadata(workspace_path):
     """Migrate metadata if it's out of date."""

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import os
 import pkg_resources
 import shutil
-import sys
 import yaml
 
 from .common import mkdir_p
@@ -104,29 +103,6 @@ def get_paths(workspace_path, profile_name, verb=None):
 
     return (metadata_path, metadata_file_path)
 
-def find_enclosing_workspaces(search_start_path):
-    """Find a catkin workspaces based on the existence of a catkin_tools
-    metadata directory starting in the path given by search_path and traversing
-    each parent directory and returns a list of workspaces.
-
-    :search_start_path: Directory which either is a catkin workspace or is
-    contained in a catkin workspace
-
-    :returns: List of path to the workspaces if found, an empty list otherwise.
-    """
-    workspaces = []
-    while search_start_path:
-        # Check if marker file exists
-        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
-        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
-            workspaces.append(search_start_path)
-
-        # Update search path or end
-        (search_start_path, child_path) = os.path.split(search_start_path)
-        if len(child_path) == 0:
-            break
-
-    return workspaces
 
 def find_enclosing_workspace(search_start_path):
     """Find a catkin workspace based on the existence of a catkin_tools
@@ -134,31 +110,24 @@ def find_enclosing_workspace(search_start_path):
     each parent directory until either finding such a directory or getting to
     the root of the filesystem.
 
-    If more than one candidate exists, print a detailed error message that
-    explains the situation and exit.
-
     :search_start_path: Directory which either is a catkin workspace or is
     contained in a catkin workspace
 
     :returns: Path to the workspace if found, `None` if not found.
     """
-    # Check if marker file exists in search_start_path
-    candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
-    if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
-        return search_start_path
+    while search_start_path:
+        # Check if marker file exists
+        candidate_path = os.path.join(search_start_path, METADATA_DIR_NAME)
+        if os.path.exists(candidate_path) and os.path.isdir(candidate_path):
+            return search_start_path
 
-    workspaces = find_enclosing_workspaces(search_start_path)
-    if not workspaces:
-        return None
-    if len(workspaces) == 1:
-        return workspaces[0]
+        # Update search path or end
+        (search_start_path, child_path) = os.path.split(search_start_path)
+        if len(child_path) == 0:
+            break
 
-    print('Multiple nested workspaces have been found for search path `{}`:\n'.format(search_start_path),
-          file=sys.stderr)
-    for workspace in workspaces:
-        print(' - {}'.format(workspace), file=sys.stderr)
-    print('\nPlease select one of them explicitly by adding the --workspace (-w) argument.', file=sys.stderr)
-    sys.exit(1)
+    return None
+
 
 def migrate_metadata(workspace_path):
     """Migrate metadata if it's out of date."""

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -164,7 +164,7 @@ def main(opts):
 
     except IOError as exc:
         # Usually happens if workspace is already underneath another catkin_tools workspace
-        print('error: could not configure catkin workspace: %s' % exc.message)
+        print('error: could not configure catkin workspace: %s' % str(exc))
         return 1
 
     return 0

--- a/catkin_tools/verbs/catkin_init/cli.py
+++ b/catkin_tools/verbs/catkin_init/cli.py
@@ -55,7 +55,7 @@ def main(opts):
 
     except IOError as exc:
         # Usually happens if workspace is already underneath another catkin_tools workspace
-        print('error: could not initialize catkin workspace: %s' % exc.message)
+        print('error: could not initialize catkin workspace: %s' % str(exc))
         return 1
 
     return 0

--- a/docs/verbs/cli/catkin_build.txt
+++ b/docs/verbs/cli/catkin_build.txt
@@ -23,8 +23,8 @@ the `catkin config` command.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
   --dry-run, -n         List the packages which will be built with the given

--- a/docs/verbs/cli/catkin_clean.txt
+++ b/docs/verbs/cli/catkin_clean.txt
@@ -9,8 +9,8 @@ Deletes various products of the build verb.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
   --dry-run, -n         Show the effects of the clean action without modifying

--- a/docs/verbs/cli/catkin_config.txt
+++ b/docs/verbs/cli/catkin_config.txt
@@ -27,8 +27,8 @@ profile.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 

--- a/docs/verbs/cli/catkin_init.txt
+++ b/docs/verbs/cli/catkin_init.txt
@@ -5,7 +5,7 @@ Initializes a given folder as a catkin workspace.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --reset               Reset (delete) all of the metadata for the given
                         workspace.

--- a/docs/verbs/cli/catkin_list.txt
+++ b/docs/verbs/cli/catkin_list.txt
@@ -8,8 +8,8 @@ Lists catkin packages in the workspace or other arbitray folders.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 

--- a/docs/verbs/cli/catkin_locate.txt
+++ b/docs/verbs/cli/catkin_locate.txt
@@ -8,8 +8,8 @@ Get the paths to various locations in a workspace.
 optional arguments:
   -h, --help            show this help message and exit
   --workspace WORKSPACE, -w WORKSPACE
-                        The path to the catkin_tools workspace or a directory
-                        contained within it (default: ".")
+                        The path to the catkin_tools workspace (default:
+                        autodetect)
   --profile PROFILE     The name of a config profile to use (default: active
                         profile)
 


### PR DESCRIPTION
Reverts #1 and #2 and replaces them by a patch which changes the automatic workspace detection in a way that only the outermost workspace is used. It is still possible to select the workspace explicitly by passing the workspace hint (`-w`, `--workspace`), but the argument needs to point to the workspace root and not to a directory contained within.

The error message and bail-out broke `catkin cd` from a directory somewhere inside the nested workspace.

Based on upstream master to open a similar patch to upstream https://github.com/catkin/catkin_tools...