### PR TITLE
Enable bash completion for catkin cd

### DIFF
--- a/completion/catkin_tools-completion.bash
+++ b/completion/catkin_tools-completion.bash
@@ -55,7 +55,7 @@ _catkin()
   _init_completion || return # this handles default completion (variables, redirection)
 
   # complete to the following verbs
-  local catkin_verbs="build clean config create init list profile run_tests"
+  local catkin_verbs="build cd clean config create init list profile run_tests"
 
   # filter for long options (from bash_completion)
   local OPTS_FILTER='s/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p'
@@ -82,6 +82,9 @@ _catkin()
       else
         COMPREPLY=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       fi
+      ;;
+    cd)
+      COMPREPLY=($(compgen -W "$(_catkin_pkgs)" -- ${cur}))
       ;;
     config)
       # list all options


### PR DESCRIPTION
This patch enables completion of package names with `catkin cd`. There are no additional arguments possible like for `catkin build`, so the case can be even simpler.