### PR TITLE
Fix installation of new cmake files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - pip install setuptools argparse catkin-pkg PyYAML psutil osrf_pycommon pyenchant sphinxcontrib-spelling
 install:
   # Install catkin_tools
-  - python setup.py develop
+  - python setup.py install
 before_script:
   # Install catkin_tools test harness dependencies
   - ./.travis.before_script.bash

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -28,7 +28,10 @@ try:
     _cmd_split(u'\u00E9')
 
     def cmd_split(s):
-        return _cmd_split(s.decode('utf-8'))
+        if sys.version_info.major == 3:
+            return _cmd_split(str(s, 'utf-8'))
+        else:
+            return _cmd_split(s.decode('utf-8'))
 except UnicodeEncodeError:
     cmd_split = _cmd_split
 

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,8 @@ setup(
     packages=find_packages(exclude=['tests*', 'docs']),
     package_data={
         'catkin_tools': [
+            'jobs/cmake/python.cmake',
+            'jobs/cmake/python_install_dir.cmake',
             'notifications/resources/linux/catkin_icon.png',
             'notifications/resources/linux/catkin_icon_red.png',
             'verbs/catkin_shell_verbs.bash',


### PR DESCRIPTION
From https://github.com/catkin/catkin_tools/pull/615:

> Follow-up on https://github.com/catkin/catkin_tools/pull/601: The cmake files were not installed, the fix only worked when installing in development mode. This PR also updates the tests to test on the properly installed, non-development, installation.

This PR also includes one other patch merged upstream since #5, https://github.com/catkin/catkin_tools/pull/627.