### PR TITLE
Fix undefined workspace variable error if no enclosing workspace has been found

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -175,10 +175,8 @@ class Context(object):
         opts_vars = vars(opts) if opts else {}
 
         # Get the workspace (either the given directory or the ws enclosing cwd)
-        workspace_hint = workspace_hint or opts_vars.get('workspace', None)
-        if workspace_hint:
-            workspace = workspace_hint
-        else:
+        workspace = workspace_hint or opts_vars.get('workspace', None)
+        if not workspace:
             workspaces = find_enclosing_workspaces(getcwd())
             if workspaces:
                 workspace = workspaces[-1]

--- a/catkin_tools/metadata.py
+++ b/catkin_tools/metadata.py
@@ -232,16 +232,6 @@ def init_metadata_root(workspace_path, reset=False):
             "Can't initialize Catkin workspace in path %s because it does "
             "not exist." % (workspace_path))
 
-    # Check if the desired workspace is enclosed in another workspace
-    marked_workspace = find_enclosing_workspaces(workspace_path)
-    if marked_workspace: marked_workspace = marked_workspace[0]
-
-    if marked_workspace and marked_workspace != workspace_path:
-        raise IOError(
-            "Can't initialize Catkin workspace in path %s because it is "
-            "already contained in another workspace: %s." %
-            (workspace_path, marked_workspace))
-
     # Construct the full path to the metadata directory
     metadata_root_path = get_metadata_root_path(workspace_path)
 


### PR DESCRIPTION
Fixes a Python error introduced in https://github.com/Intermodalics/catkin_tools/pull/3: Without a `workspace` argument (`-w`) and if no workspace was found by `find_enclosing_workspaces(getcwd())`, the `workspace` variable was undefined in [line 186](https://github.com/Intermodalics/catkin_tools/blob/b6867b190d40fc1d1e024e014523bf6884967af4/catkin_tools/context.py#L186).