### PR TITLE
Fix implicit creation of a new context if none exist yet

### DIFF
--- a/catkin_tools/context.py
+++ b/catkin_tools/context.py
@@ -174,12 +174,15 @@ class Context(object):
         # Initialize dictionary version of opts namespace
         opts_vars = vars(opts) if opts else {}
 
-        # Get the workspace (either the given directory or the ws enclosing cwd)
+        # Get the workspace (either the given directory or the outermost ws enclosing cwd)
         workspace = workspace_hint or opts_vars.get('workspace', None)
         if not workspace:
-            workspaces = find_enclosing_workspaces(getcwd())
+            workspace_hint = getcwd()
+            workspaces = find_enclosing_workspaces(workspace_hint)
             if workspaces:
                 workspace = workspaces[-1]
+            else:
+                workspace = workspace_hint
 
         if not workspace:
             if strict or not workspace_hint:


### PR DESCRIPTION
https://github.com/Intermodalics/catkin_tools/pull/7 was still not right yet. The implicit creation of a new workspace in the current working directory failed with:

```
ERROR: No workspace found containing '/build/im-vps'
Traceback (most recent call last):
  File "/usr/local/bin/catkin", line 11, in <module>
    load_entry_point('catkin-tools==0.5.0', 'console_scripts', 'catkin')()
  File "/usr/local/lib/python3.6/dist-packages/catkin_tools/commands/catkin.py", line 272, in main
    catkin_main(sysargs)
  File "/usr/local/lib/python3.6/dist-packages/catkin_tools/commands/catkin.py", line 267, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/usr/local/lib/python3.6/dist-packages/catkin_tools/verbs/catkin_config/cli.py", line 154, in main
    if not context.initialized() and do_init:
AttributeError: 'NoneType' object has no attribute 'initialized'
```

if no enclosing workspace exists yet. That is whenever `Context.load()` was called without the `strict=True` argument, it must not return `None`, but a new context valid for the current working directory.

Comparison of the relevant snippet to the [upstream version](https://github.com/catkin/catkin_tools/blob/5e5734849f237deab303bfc545ef8f5c576b6fad/catkin_tools/context.py):
```diff
-        # Get the workspace (either the given directory or the enclosing ws)
-        workspace_hint = workspace_hint or opts_vars.get('workspace', None) or getcwd()
-        workspace = find_enclosing_workspace(workspace_hint)
+        # Get the workspace (either the given directory or the most outer ws enclosing cwd)
+        workspace = workspace_hint or opts_vars.get('workspace', None)
+        if not workspace:
+            workspace_hint = getcwd()
+            workspaces = find_enclosing_workspaces(workspace_hint)
+            if workspaces:
+                workspace = workspaces[-1]
+            else:
+                workspace = workspace_hint
+
         if not workspace:
             if strict or not workspace_hint:
                 return None
             else:
                 workspace = workspace_hint
         opts_vars['workspace'] = workspace
```

So the only change in behavior is that if the workspace was not provided explicitly as `workspace_hint` or via the `workspace` option, and if more than one enclosing workspace is found in the current working directory, we want to use the outermost one and not the innermost.